### PR TITLE
Adds condition to start script for vagrant saved status

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 VM_STATUS=$(vagrant status --machine-readable | grep ",state," | egrep -o '([a-z]*)$')
-if [ "${VM_STATUS}" = "poweroff" ]; then
+if [ "${VM_STATUS}" = "poweroff" ] || [ "${VM_STATUS}" = "saved" ]; then
   vagrant up
 fi
 


### PR DESCRIPTION
My vagrant box was just in the "saved" status and I noticed that in this case you also have to run `vagrant up` before being able to ssh into the box.