### PR TITLE
Run credo as part of the ci build

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -13,7 +13,7 @@
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
         included: ["lib/", "test/"],
-        excluded: [~r"/_build/", ~r"/deps/"]
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/test/support/"]
       },
       #
       requires: [],

--- a/.credo.exs
+++ b/.credo.exs
@@ -51,7 +51,7 @@
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc, false},
         {Credo.Check.Readability.ModuleNames},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},
         {Credo.Check.Readability.PreferImplicitTry},

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_script:
   - psql -c 'create database advisor_test;' -U postgres
   - psql -c 'create extension pgcrypto;' -U postgres
 
+script:
+  - MIX_ENV=test mix ci
+
 cache:
   directories:
     - _build

--- a/lib/advisor/application.ex
+++ b/lib/advisor/application.ex
@@ -6,14 +6,9 @@ defmodule Advisor.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
-    # Define workers and child supervisors to be supervised
     children = [
-      # Start the Ecto repository
       supervisor(Advisor.Repo, []),
-      # Start the endpoint when the application starts
       supervisor(Advisor.Web.Endpoint, []),
-      # Start your own worker by calling: Advisor.Worker.start_link(arg1, arg2, arg3)
-      # worker(Advisor.Worker, [arg1, arg2, arg3]),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/advisor/core/answer_finder.ex
+++ b/lib/advisor/core/answer_finder.ex
@@ -8,7 +8,11 @@ defmodule Advisor.Core.AnswerFinder do
   end
 
   defp find_all(advisory) do
-    query = from answer in Answer, where: answer.advice_request_id == ^advisory.id
-    %{advisory: advisory, answers: Repo.all(query)}
+    answers_from_advisory = from a in Answer,
+      where: a.advice_request_id == ^advisory.id
+
+    answers = Repo.all(answers_from_advisory)
+
+    %{advisory: advisory, answers: answers}
   end
 end

--- a/lib/advisor/core/creator.ex
+++ b/lib/advisor/core/creator.ex
@@ -4,21 +4,27 @@ defmodule Advisor.Core.Creator do
   alias Advisor.Core.AdviceRequest.Advisory
   alias Advisor.Repo
 
-  def create(proposal) do
-    {:ok, questionnaire} = Repo.insert(%Questionnaire{question_ids: proposal.questions,
-                               requester_id: proposal.requester})
+  def create(%{questions: questions,
+               requester: requester,
+               advisors: advisors}) do
+    {:ok, questionnaire} = Repo.insert(%Questionnaire{question_ids: questions,
+                               requester_id: requester})
 
-    advice_requests = Enum.map(proposal.advisors, fn(advisor) ->
+    advice_requests = Enum.map(advisors, fn(advisor) ->
       %{questionnaire_id: questionnaire.id,
-        requester_id: proposal.requester,
+        requester_id: requester,
         advisor_id: advisor}
     end)
 
     advisories = AdviceRequest
                  |> Repo.insert_all(advice_requests, returning: true)
                  |> elem(1)
-                 |> Enum.map(&%Advisory{advisor: People.find_by_id(&1.advisor_id), advice_id: &1.id})
+                 |> Enum.map(&to_advisory/1)
 
     {:ok, %Created{questionnaire:  questionnaire.id, advisories: advisories}}
+  end
+
+  defp to_advisory(%{advisor_id: advisor_id, id: id}) do
+    %Advisory{advisor: People.find_by_id(advisor_id), advice_id: id}
   end
 end

--- a/lib/advisor/web/controllers/advice_request_controller.ex
+++ b/lib/advisor/web/controllers/advice_request_controller.ex
@@ -7,11 +7,11 @@ defmodule Advisor.Web.AdviceRequestController do
   plug  Advisor.Web.Authentication.Gatekeeper
 
   def create(conn, params) do
-    {links, progress_link} = params
-                             |> QuestionnaireProposal.for_requester(found_in(conn))
-                             |> Creator.create
-                             |> Links.generate
+    {links, progress} = params
+                        |> QuestionnaireProposal.for_requester(found_in(conn))
+                        |> Creator.create
+                        |> Links.generate
 
-    render conn, "links.html", links: links, progress_link: progress_link
+    render conn, "links.html", links: links, progress_link: progress
   end
 end

--- a/lib/advisor/web/questionnaire_proposal.ex
+++ b/lib/advisor/web/questionnaire_proposal.ex
@@ -4,8 +4,9 @@ defmodule Advisor.Web.QuestionnaireProposal do
             advisors: [],
             questions: []
 
-
-  def for_requester(%{"proposal" => %{"group_lead" => lead, "advisors" => people, "questions" => questions}}, %{id: id}) do
+  def for_requester(%{"proposal" => %{"group_lead" => lead,
+                                      "advisors" => people,
+                                      "questions" => questions}}, %{id: id}) do
     with {:ok, lead} <- parse(lead),
          {:ok, people} <- parse(people),
          {:ok, questions} <- parse(questions),
@@ -16,7 +17,7 @@ defmodule Advisor.Web.QuestionnaireProposal do
   end
 
   def parse(map) when is_map(map) do
-    map = Enum.filter_map(map, fn({_, value}) -> value == "true" end, fn({key, _}) -> parse!(key) end)
+    map = Enum.filter_map(map, &truthish/1, fn({key, _}) -> parse!(key) end)
 
     {:ok, map}
   end
@@ -26,6 +27,9 @@ defmodule Advisor.Web.QuestionnaireProposal do
       _ -> :could_not_parse_to_integer
     end
   end
+
+  def truthish({_key, "true"}), do: true
+  def truthish(_pair), do: false
 
   def parse!(potential) do
     case Integer.parse(potential) do

--- a/lib/advisor/web/questionnaire_proposal.ex
+++ b/lib/advisor/web/questionnaire_proposal.ex
@@ -17,7 +17,7 @@ defmodule Advisor.Web.QuestionnaireProposal do
   end
 
   def parse(map) when is_map(map) do
-    map = Enum.filter_map(map, &truthish/1, fn({key, _}) -> parse!(key) end)
+    map = Enum.filter_map(map, &truthy/1, fn({key, _}) -> parse!(key) end)
 
     {:ok, map}
   end
@@ -28,8 +28,8 @@ defmodule Advisor.Web.QuestionnaireProposal do
     end
   end
 
-  def truthish({_key, "true"}), do: true
-  def truthish(_pair), do: false
+  def truthy({_key, "true"}), do: true
+  def truthy(_pair), do: false
 
   def parse!(potential) do
     case Integer.parse(potential) do

--- a/lib/advisor/web/views/landing_page_view.ex
+++ b/lib/advisor/web/views/landing_page_view.ex
@@ -1,7 +1,8 @@
 defmodule Advisor.Web.LandingPageView do
+  alias Phoenix.Controller
   use Advisor.Web, :view
 
   def csrf_token() do
-    Phoenix.Controller.get_csrf_token()
+    Controller.get_csrf_token()
   end
 end

--- a/lib/advisor/web/web.ex
+++ b/lib/advisor/web/web.ex
@@ -30,7 +30,9 @@ defmodule Advisor.Web do
                         namespace: Advisor.Web
 
       # Import convenience functions from controllers
-      import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]
+      import Phoenix.Controller, only: [get_csrf_token: 0,
+                                        get_flash: 2,
+                                        view_module: 1]
 
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Advisor.Mixfile do
     ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
      "ecto.reset": ["ecto.drop", "ecto.setup"],
      "test": ["ecto.create --quiet", "ecto.migrate", "test"],
-     "ci": ["test", "credo --ignore readability"]
+     "ci": ["test", "credo --strict"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Advisor.Mixfile do
      {:ex_unit_notifier, "~> 0.1.3", only: :test},
      {:mix_test_watch, "~> 0.3.3"},
      {:floki, "~> 0.17.0", only: :test},
-     {:credo, "~> 0.7", only: [:dev, :test]}]
+     {:credo, "~> 0.7", only: [:dev, :test], runtime: false}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.
@@ -50,6 +50,8 @@ defmodule Advisor.Mixfile do
   defp aliases do
     ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
      "ecto.reset": ["ecto.drop", "ecto.setup"],
-     "test": ["ecto.create --quiet", "ecto.migrate", "test"]]
+     "test": ["ecto.create --quiet", "ecto.migrate", "test"],
+     "ci": ["test", "credo --ignore readability"]
+    ]
   end
 end

--- a/test/core/creator_test.exs
+++ b/test/core/creator_test.exs
@@ -1,17 +1,7 @@
 defmodule Advisor.Core.CreatorTest do
-  use ExUnit.Case
+  use Advisor.DataCase
   alias Advisor.Core.Creator
   alias Advisor.Web.QuestionnaireProposal
-
-  setup do
-    # Explicitly get a connection before each test
-    # By default the test is wrapped in a transaction
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Advisor.Repo)
-
-    # The :shared mode allows a process to share
-    # its connection with any other process automatically
-    Ecto.Adapters.SQL.Sandbox.mode(Advisor.Repo, {:shared, self()})
-  end
 
   test "creates a simple questionnaire" do
     proposal = %QuestionnaireProposal{group_lead: 1,
@@ -21,7 +11,7 @@ defmodule Advisor.Core.CreatorTest do
 
     {:ok, created} = Creator.create(proposal)
     assert created.questionnaire
-    assert Enum.map(created.advisories, fn(advisory) -> advisory.advisor.id end) == [2, 9]
+    assert Enum.map(created.advisories, &(&1.advisor.id)) == [2, 9]
   end
 
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,4 +1,3 @@
-# credo:disable-for-this-file
 defmodule Advisor.Web.ConnCase do
   @moduledoc """
   This module defines the test case to be used by

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file
 defmodule Advisor.Web.ConnCase do
   @moduledoc """
   This module defines the test case to be used by
@@ -25,7 +26,6 @@ defmodule Advisor.Web.ConnCase do
       @endpoint Advisor.Web.Endpoint
     end
   end
-
 
   setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Advisor.Repo)

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -1,4 +1,3 @@
-# credo:disable-for-this-file
 defmodule Advisor.DataCase do
   @moduledoc """
   This module defines the setup for tests requiring

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file
 defmodule Advisor.DataCase do
   @moduledoc """
   This module defines the setup for tests requiring

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,5 @@
+# credo:disable-for-this-file
 ExUnit.configure formatters: [ExUnit.CLIFormatter, ExUnitNotifier]
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(Advisor.Repo, :manual)
-

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
-# credo:disable-for-this-file
 ExUnit.configure formatters: [ExUnit.CLIFormatter, ExUnitNotifier]
 ExUnit.start()
 

--- a/test/web/authentication/gatekeeper_test.exs
+++ b/test/web/authentication/gatekeeper_test.exs
@@ -3,7 +3,6 @@ defmodule Advisor.Web.Authentication.GatekeeprTest do
   alias Advisor.Web.Authentication.Gatekeeper
   alias Advisor.Core.Person
 
-
   test "halts the request if not user_id found in session" do
     conn = build_conn() |> Gatekeeper.call(%{})
 

--- a/test/web/controllers/advice_request_controller_test.exs
+++ b/test/web/controllers/advice_request_controller_test.exs
@@ -2,9 +2,12 @@ defmodule Advisor.Web.AdviceRequestControllerTest do
   use Advisor.Web.ConnCase
 
   test "creates the proper questionnaire", %{conn: conn} do
+    proposal = %{:group_lead => "11",
+                 :advisors => %{"4" => "true"},
+                 :questions =>  %{"13" => "true"}}
     conn = conn
            |> login_as(11)
-           |> post("/request", [proposal: %{:group_lead => "11", :advisors => %{"4" => "true"}, :questions =>  %{"13" => "true"}}])
+           |> post("/request", [proposal: proposal])
 
     response = html_response(conn, 200)
 

--- a/test/web/controllers/progress_page_test.exs
+++ b/test/web/controllers/progress_page_test.exs
@@ -4,8 +4,6 @@ defmodule Advisor.Web.ProgressPageTest do
   alias Advisor.Web.Links
   alias Advisor.Core.{Creator, People}
 
-
-
   test "shows the progress filling in the questionnaires", %{conn: conn} do
     rabea = People.find_by(name: "Rabea Gleissner")
     felipe = People.find_by(name: "Felipe Sere")

--- a/test/web/controllers/questionnaire_page_test.exs
+++ b/test/web/controllers/questionnaire_page_test.exs
@@ -19,7 +19,6 @@ defmodule Advisor.Web.RequestPageTest do
              |> Enum.at(0)
              |> Floki.text == "Hello Felipe Sere!"
 
-
     # maybe split this later into group_lead and advisor
     assert response
              |> Floki.find(".people-picker li")


### PR DESCRIPTION
Running `mix credo --strict` throws no warnings at the moment.
To see what CI would do at the moment run `MIX_ENV=test mix ci`
Rules are up for debate...

Closes #24 