### PR TITLE
Only allow group_leads to see the progress page

### DIFF
--- a/lib/advisor/web/controllers/progress_page.ex
+++ b/lib/advisor/web/controllers/progress_page.ex
@@ -2,6 +2,8 @@ defmodule Advisor.Web.ProgressPage do
   use Advisor.Web, :controller
   alias Advisor.Core.{People, AdvisoryFinder, AnswerFinder, QuestionnaireFinder}
 
+  plug  Advisor.Web.Authentication.Gatekeeper, only: :group_leads
+
   def index(conn, %{"id" => id}) do
     advisories = AdvisoryFinder.gather_for_questionnaire(id)
     questionnaire = QuestionnaireFinder.find(id)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,6 +23,10 @@ defmodule Advisor.Web.ConnCase do
 
       # The default endpoint for testing
       @endpoint Advisor.Web.Endpoint
+
+      def login_as(conn, id) do
+        assign(conn, :user_id, id)
+      end
     end
   end
 

--- a/test/web/authentication/gatekeeper_test.exs
+++ b/test/web/authentication/gatekeeper_test.exs
@@ -3,8 +3,10 @@ defmodule Advisor.Web.Authentication.GatekeeprTest do
   alias Advisor.Web.Authentication.Gatekeeper
   alias Advisor.Core.Person
 
+  @default_opts Gatekeeper.init([])
+
   test "halts the request if not user_id found in session" do
-    conn = build_conn() |> Gatekeeper.call(%{})
+    conn = build_conn() |> Gatekeeper.call(@default_opts)
 
     assert conn.status == 302
   end
@@ -12,7 +14,7 @@ defmodule Advisor.Web.Authentication.GatekeeprTest do
   test "presrves original destination in session" do
     conn = "/foo"
            |> get()
-           |> Gatekeeper.call(%{})
+           |> Gatekeeper.call(@default_opts)
            |> fetch_cookies()
 
     assert conn.cookies["target"] == "/foo"
@@ -21,15 +23,26 @@ defmodule Advisor.Web.Authentication.GatekeeprTest do
   test "loads the user if it available" do
     conn = "/foo"
            |> get()
-           |> with_user("11")
-           |> Gatekeeper.call(%{})
+           |> with_user(name: "Chris Jordan")
+           |> Gatekeeper.call(@default_opts)
 
     assert %Person{} = conn.assigns[:user]
   end
 
-  defp with_user(conn, id) do
-    conn
-    |> put_req_cookie("user", id)
+  test "prevents a regular user from accessing a page for group leads" do
+    conn = "/foo"
+           |> get()
+           |> with_user(name: "Chris Jordan")
+           |> Gatekeeper.call(:group_leads)
+
+    assert conn.status == 302
+  end
+
+  defp with_user(conn, [name: name]) do
+    case Advisor.Core.People.find_by(name: name) do
+      nil -> raise "Could not finder user #{name}"
+      %{id: id} -> put_req_cookie(conn, "user", Integer.to_string(id))
+    end
   end
 
   defp get(path) do

--- a/test/web/authentication/gatekeeper_test.exs
+++ b/test/web/authentication/gatekeeper_test.exs
@@ -1,7 +1,7 @@
 defmodule Advisor.Web.Authentication.GatekeeprTest do
   use Advisor.Web.ConnCase
   alias Advisor.Web.Authentication.Gatekeeper
-  alias Advisor.Core.Person
+  alias Advisor.Core.{Person, People}
 
   @default_opts Gatekeeper.init([])
 
@@ -39,7 +39,7 @@ defmodule Advisor.Web.Authentication.GatekeeprTest do
   end
 
   defp with_user(conn, [name: name]) do
-    case Advisor.Core.People.find_by(name: name) do
+    case People.find_by(name: name) do
       nil -> raise "Could not finder user #{name}"
       %{id: id} -> put_req_cookie(conn, "user", Integer.to_string(id))
     end

--- a/test/web/controllers/advice_request_controller_test.exs
+++ b/test/web/controllers/advice_request_controller_test.exs
@@ -21,8 +21,4 @@ defmodule Advisor.Web.AdviceRequestControllerTest do
 
     assert redirected_to(conn) == "/"
   end
-
-  def login_as(conn, id) do
-    assign(conn, :user_id, id)
-  end
 end

--- a/test/web/controllers/progress_page_test.exs
+++ b/test/web/controllers/progress_page_test.exs
@@ -18,7 +18,10 @@ defmodule Advisor.Web.ProgressPageTest do
                          |> Creator.create
                          |> Links.generate
 
-    conn = conn |> get(progress_link)
+    conn = conn
+           |> assign(:user_id, felipe.id)
+           |> get(progress_link)
+
     html = html_response(conn, 200)
 
     assert requester(html) =~ "Rabea Gleissner"


### PR DESCRIPTION
This PR refactors the Gatekeeper a little bit to allow to differentiate regular users from group_leads.
This way, certain pages can only be visited with a group_lead present.