### PR TITLE
Correct progress page [DO NOT MERGE]

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -49,7 +49,7 @@
 
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 100},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc, false},
         {Credo.Check.Readability.ModuleNames},

--- a/lib/advisor/web/controllers/progress_page.ex
+++ b/lib/advisor/web/controllers/progress_page.ex
@@ -14,10 +14,13 @@ defmodule Advisor.Web.ProgressPage do
                     |> Enum.group_by(&(completed?(&1.answers, questionnaire)),
                                      &(People.find_by(&1.advisory)))
 
+    completed = Map.get(by_completion, true, [])
+    incomplete = Map.get(by_completion, false, [])
+
     render conn, "index.html", requester: requester,
-                               completed: Map.get(by_completion, true, []),
-                               incomplete: Map.get(by_completion, false, []),
-                               all_complete: true, # TODO
+                               completed: completed,
+                               incomplete: incomplete,
+                               all_complete:  incomplete == [],
                                questionnaire: questionnaire
 
   end

--- a/lib/advisor/web/templates/progress_page/index.html.eex
+++ b/lib/advisor/web/templates/progress_page/index.html.eex
@@ -4,7 +4,7 @@
   </header>
   <ul class="advisors">
     <%= for person <- @completed do %>
-      <%= render "_advisor-progress.html", person: person %>
+      <%= render "_advisor-progress.html", person: person, state: true %>
     <% end %>
     <%= for person <- @incomplete do %>
       <%= render "_advisor-progress.html", person: person, state: :incomplete %>

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -31,7 +31,6 @@ defmodule Advisor.Web.ConnCase do
       def login_as(conn, id) do
         assign(conn, :user_id, id)
       end
-
     end
   end
 

--- a/test/web/controllers/progress_page_test.exs
+++ b/test/web/controllers/progress_page_test.exs
@@ -12,16 +12,37 @@ defmodule Advisor.Web.ProgressPageTest do
                               group_lead: "Felipe Sere",
                               questions: @sample_questions)
 
-    {_, progress_link} = proposal
+    {_, progress_page} = proposal
                          |> Creator.create
                          |> Links.generate
 
     conn
     |> login_as("Felipe Sere")
-    |> get(progress_link)
+    |> get(progress_page)
     |> html_response(200)
     |> has_requester("Rabea Gleissner")
     |> has_advisors(["Chris Jordan", "Priya Patil"])
+  end
+
+  test "shows that an advisors has completed the advice form", %{conn: conn} do
+    proposal = Proposal.build(for: "Rabea Gleissner",
+                              advisors: ["Chris Jordan"],
+                              group_lead: "Felipe Sere",
+                              questions: [1])
+
+    {[%{link: link}], progress_page} = proposal
+                                       |> Creator.create
+                                       |> Links.generate
+
+    conn
+    |> login_as("Chris Jordan")
+    |> post(link, ["1": "someting"])
+
+    conn
+    |> login_as("Felipe Sere")
+    |> get(progress_page)
+    |> html_response(200)
+    |> has_completed_advice()
   end
 
   def has_requester(html, requester_name) do
@@ -31,6 +52,10 @@ defmodule Advisor.Web.ProgressPageTest do
 
   def has_advisors(html, advisors_names) do
     assert advisors(html) == advisors_names
+    html
+  end
+
+  def has_completed_advice(html) do
     html
   end
 

--- a/test/web/controllers/progress_page_test.exs
+++ b/test/web/controllers/progress_page_test.exs
@@ -6,12 +6,16 @@ defmodule Advisor.Web.ProgressPageTest do
 
   @sample_questions [5, 6]
 
-  test "shows the progress filling in the questionnaires", %{conn: conn} do
+  setup do
     proposal = Proposal.build(for: "Rabea Gleissner",
                               advisors: ["Chris Jordan", "Priya Patil"],
                               group_lead: "Felipe Sere",
                               questions: @sample_questions)
+    [proposal: proposal]
+  end
 
+  test "shows the progress filling in the questionnaires", %{conn: conn,
+                                                             proposal: proposal} do
     {_, progress_page} = proposal
                          |> Creator.create
                          |> Links.generate
@@ -24,15 +28,12 @@ defmodule Advisor.Web.ProgressPageTest do
     |> has_advisors(["Chris Jordan", "Priya Patil"])
   end
 
-  test "shows that an advisors has completed the advice form", %{conn: conn} do
-    proposal = Proposal.build(for: "Rabea Gleissner",
-                              advisors: ["Chris Jordan"],
-                              group_lead: "Felipe Sere",
-                              questions: [1])
-
-    {[%{link: link}], progress_page} = proposal
-                                       |> Creator.create
-                                       |> Links.generate
+  test "shows that an advisors has completed the advice form", %{conn: conn,
+                                                                 proposal: proposal} do
+    proposal =  %{proposal | questions: [1]}
+    {[%{link: link} | _], progress_page} = proposal
+                                           |> Creator.create
+                                           |> Links.generate
 
     conn
     |> login_as("Chris Jordan")
@@ -43,6 +44,38 @@ defmodule Advisor.Web.ProgressPageTest do
     |> get(progress_page)
     |> html_response(200)
     |> has_completed_advice()
+    |> has_continue_button_with("Waiting for further responses")
+  end
+
+  test "all completed feedback", %{conn: conn, proposal: proposal} do
+    {[%{link: cj}, %{link: priya}], progress_page} = proposal
+                                                    |> Creator.create
+                                                    |> Links.generate
+
+    answers = ["1": "something", "2": "else"]
+
+    conn
+    |> login_as("Chris Jordan")
+    |> post(cj, answers)
+
+    conn
+    |> login_as("Priya Patil")
+    |> post(priya, answers)
+
+    conn
+    |> login_as("Felipe Sere")
+    |> get(progress_page)
+    |> html_response(200)
+    |> has_continue_button_with("We are good to go")
+  end
+
+  def has_continue_button_with(html, text) do
+    button = html
+             |> Floki.find(".button")
+             |> Floki.text
+
+    assert button =~ text
+    html
   end
 
   def has_requester(html, requester_name) do
@@ -56,6 +89,11 @@ defmodule Advisor.Web.ProgressPageTest do
   end
 
   def has_completed_advice(html) do
+    assert html
+           |> Floki.find(".completeness")
+           |> Enum.map(&Floki.text/1)
+           |> Enum.any?(&(&1 =~ "Completed"))
+
     html
   end
 

--- a/test/web/controllers/progress_page_test.exs
+++ b/test/web/controllers/progress_page_test.exs
@@ -2,30 +2,36 @@ defmodule Advisor.Web.ProgressPageTest do
   use Advisor.Web.ConnCase
   alias Advisor.Web.QuestionnaireProposal, as: Proposal
   alias Advisor.Web.Links
-  alias Advisor.Core.{Creator, People}
+  alias Advisor.Core.Creator
+
+  @sample_questions [5, 6]
 
   test "shows the progress filling in the questionnaires", %{conn: conn} do
-    rabea = People.find_by(name: "Rabea Gleissner")
-    felipe = People.find_by(name: "Felipe Sere")
-    cj = People.find_by(name: "Chris Jordan")
-
-    proposal = %Proposal{group_lead: 1,
-                         requester: rabea.id,
-                         advisors: [felipe.id, cj.id],
-                         questions: [5, 6]}
+    proposal = Proposal.build(for: "Rabea Gleissner",
+                              advisors: ["Chris Jordan", "Priya Patil"],
+                              group_lead: "Felipe Sere",
+                              questions: @sample_questions)
 
     {_, progress_link} = proposal
                          |> Creator.create
                          |> Links.generate
 
-    conn = conn
-           |> assign(:user_id, felipe.id)
-           |> get(progress_link)
+    conn
+    |> login_as("Felipe Sere")
+    |> get(progress_link)
+    |> html_response(200)
+    |> has_requester("Rabea Gleissner")
+    |> has_advisors(["Chris Jordan", "Priya Patil"])
+  end
 
-    html = html_response(conn, 200)
+  def has_requester(html, requester_name) do
+    assert requester(html) =~ requester_name
+    html
+  end
 
-    assert requester(html) =~ "Rabea Gleissner"
-    assert advisors(html)  == ["Felipe Sere", "Chris Jordan"]
+  def has_advisors(html, advisors_names) do
+    assert advisors(html) == advisors_names
+    html
   end
 
   def requester(html) do


### PR DESCRIPTION
Based on #21, correct the display of the 'progress page', taking into account whether people have actually completed the questionnaire.