### PR TITLE
Prevent wrong advisor accessing page

### DIFF
--- a/lib/advisor/core/advisory_finder.ex
+++ b/lib/advisor/core/advisory_finder.ex
@@ -11,4 +11,7 @@ defmodule Advisor.Core.AdvisoryFinder do
   def find(id) do
     Repo.get(AdviceRequest, id)
   end
+  def find(id, [for_user: %{id: user_id}]) do
+    Repo.one(from ar in AdviceRequest, where: ar.id == ^id and ar.advisor_id == ^user_id)
+  end
 end

--- a/lib/advisor/web/controllers/login_controller.ex
+++ b/lib/advisor/web/controllers/login_controller.ex
@@ -8,10 +8,18 @@ defmodule Advisor.Web.LoginController do
     if user do
       conn
       |> put_resp_cookie("user", "#{user.id}")
-      |> redirect(to: "/request")
+      |> look_for_redirect
+      |> redirect
     else
       conn
       |> redirect(to: "/")
     end
   end
+
+  def look_for_redirect(conn) do
+    {conn, conn.cookies["target"]}
+  end
+
+  def redirect({conn, nil}), do: redirect(conn, to: "/request")
+  def redirect({conn, destination}), do: redirect(conn, to: destination)
 end

--- a/lib/advisor/web/controllers/provide_advice_controller.ex
+++ b/lib/advisor/web/controllers/provide_advice_controller.ex
@@ -18,7 +18,9 @@ defmodule Advisor.Web.ProvideAdviceController do
                                        questions: questions,
                                        advice_id: id)
     else
-      redirect(conn, to: "/")
+      conn
+      |> put_resp_cookie("target", conn.request_path)
+      |> redirect(to: "/")
     end
   end
 

--- a/lib/advisor/web/controllers/provide_advice_controller.ex
+++ b/lib/advisor/web/controllers/provide_advice_controller.ex
@@ -3,15 +3,23 @@ defmodule Advisor.Web.ProvideAdviceController do
   alias Advisor.Core.{AdvisoryFinder, People, QuestionnaireFinder,
                       QuestionFinder, Answer}
   alias Advisor.Repo
+  import Advisor.Web.Authentication.User, only: [found_in: 1]
+
+  plug  Advisor.Web.Authentication.Gatekeeper
 
   def index(conn, %{"id" => id}) do
-    advice_request = AdvisoryFinder.find(id)
-    questionnaire = QuestionnaireFinder.find(advice_request.questionnaire_id)
-    questions = QuestionFinder.find_all(questionnaire.question_ids)
-    requester = People.find_by(id: advice_request.requester_id)
-    render conn, "advice-form.html", requester: requester,
-                                     questions: questions,
-                                     advice_id: id
+    advice_request = AdvisoryFinder.find(id, for_user: found_in(conn))
+
+    if advice_request do
+      questionnaire = QuestionnaireFinder.find(advice_request.questionnaire_id)
+      questions = QuestionFinder.find_all(questionnaire.question_ids)
+      requester = People.find_by(id: advice_request.requester_id)
+      render(conn, "advice-form.html", requester: requester,
+                                       questions: questions,
+                                       advice_id: id)
+    else
+      redirect(conn, to: "/")
+    end
   end
 
   def create(conn, params) do
@@ -19,9 +27,7 @@ defmodule Advisor.Web.ProvideAdviceController do
     render conn, "thank-you.html"
   end
 
-  def all_answers(params) do
-    %{"id" => advice_request_id} = params
-
+  def all_answers(%{"id" => advice_request_id} = params) do
     Enum.reduce(params, [], fn({question_id, answer}, acc) ->
       case Integer.parse(question_id) do
         {id, ""} -> acc ++ [

--- a/test/web/controllers/login_controller_test.exs
+++ b/test/web/controllers/login_controller_test.exs
@@ -14,4 +14,12 @@ defmodule Advisor.Web.LoginControllerTest do
     assert redirected_to(conn) == "/"
     refute conn.cookies["user"]
   end
+
+  test "Redirect to original path if this was a bounced login", %{conn: conn} do
+    conn = conn
+           |> put_req_cookie("target", "/foo/bar")
+           |> post("/begin", [email: "felipe@example.com"])
+
+    assert redirected_to(conn) == "/foo/bar"
+  end
 end

--- a/test/web/controllers/provide_advice_controller_test.exs
+++ b/test/web/controllers/provide_advice_controller_test.exs
@@ -31,6 +31,7 @@ defmodule Advisor.Web.ProvideAdviceControllerTest do
            |> get(felipes_advice_link)
 
     assert conn |> redirected_to() == "/"
+    assert conn.cookies["target"] == felipes_advice_link
   end
 
   def has_header(html, header) do

--- a/test/web/controllers/provide_advice_controller_test.exs
+++ b/test/web/controllers/provide_advice_controller_test.exs
@@ -4,12 +4,16 @@ defmodule Advisor.Web.ProvideAdviceControllerTest do
   alias Advisor.Web.Links
   alias Advisor.Core.Creator
 
-  test "renders the form", %{conn: conn} do
-    {links, _, _} = create_questionnaire(for: "Rabea Gleissner",
-                                      advisors: ["Felipe Sere", "Chris Jordan"],
-                                      group_lead: "Jim Suchy",
-                                      questions: [5, 6])
+  setup do
+    {links, progress, _} = create_questionnaire(for: "Rabea Gleissner",
+                                                advisors: ["Felipe Sere", "Chris Jordan"],
+                                                group_lead: "Jim Suchy",
+                                                questions: [5, 6])
 
+    [links: links, progress: progress]
+  end
+
+  test "renders the form", %{conn: conn, links: links} do
     felipes_advice = advisory_for(links, "Felipe Sere")
 
     conn
@@ -17,6 +21,16 @@ defmodule Advisor.Web.ProvideAdviceControllerTest do
     |> get(felipes_advice)
     |> html_response(200)
     |> has_header("Advice for Rabea Gleissner")
+  end
+
+  test "force login if incorrect advisor is authenticated", %{conn: conn, links: links} do
+    felipes_advice_link = advisory_for(links, "Felipe Sere")
+
+    conn = conn
+           |> login_as("Rabea Gleissner")
+           |> get(felipes_advice_link)
+
+    assert conn |> redirected_to() == "/"
   end
 
   def has_header(html, header) do


### PR DESCRIPTION
When trying to see the questionnaire with the wrong user, we will send them back to the login and keep their 'target', so the login can then redirect them back.