### PR TITLE
Show a single login button upon redirects

### DIFF
--- a/lib/advisor/web/controllers/landing_page.ex
+++ b/lib/advisor/web/controllers/landing_page.ex
@@ -2,8 +2,14 @@ defmodule Advisor.Web.LandingPage do
   use Advisor.Web, :controller
 
   def index(conn, _params) do
+    target = case conn.cookies["target"] do
+      nil  -> false
+      "deleted" -> false
+      x -> x
+    end
+
     render conn, "index.html", button: "Ask for advice",
-                               target: false,
+                               target: target,
                                message: false
   end
 end

--- a/lib/advisor/web/controllers/login_controller.ex
+++ b/lib/advisor/web/controllers/login_controller.ex
@@ -2,12 +2,16 @@ defmodule Advisor.Web.LoginController do
   use Advisor.Web, :controller
   alias Advisor.Core.People
 
-  def index(conn, %{"email" => email, "dashboard" => _nothing}) do
+  def index(conn, %{"email" => email, "submit" => "dashboard"}) do
     login(conn, as: email, redirect_to: "/dashboard")
   end
 
-  def index(conn, %{"email" => email, "request" => _nothing}) do
-    target = conn.cookies["target"] || "/request"
+  def index(conn, %{"email" => email, "submit" => "advice"}) do
+    login(conn, as: email, redirect_to: "/request")
+  end
+
+  def index(conn, %{"email" => email, "submit" => "redirect"}) do
+    target = conn.cookies["target"] || "/"
 
     login(conn, as: email, redirect_to: target)
   end
@@ -18,15 +22,12 @@ defmodule Advisor.Web.LoginController do
     if user do
       conn
       |> put_resp_cookie("user", "#{user.id}")
+      |> put_resp_cookie("target", "deleted")
       |> redirect(to: destination)
     else
       conn
       |> redirect(to: "/")
     end
-  end
-
-  def look_for_redirect(conn) do
-    {conn, conn.cookies["target"]}
   end
 
   def redirect({conn, nil}), do: redirect(conn, to: "/request")

--- a/lib/advisor/web/templates/landing_page/index.html.eex
+++ b/lib/advisor/web/templates/landing_page/index.html.eex
@@ -10,10 +10,10 @@
       <input type="hidden" name="_csrf_token" value="<%= get_csrf_token() %>">
       <%= if @target do %>
         <input type="hidden" name="target" value="<%= @target %>">
-        <button type="submit"  class="button primary" name="submit" value="redirect">Login</button>
+        <button type="submit" class="button primary" name="submit" value="redirect">Login</button>
       <% else %>
-        <button type="submit"  class="button primary" name="submit" value="advice">Ask for advice</button>
-        <button type="submit"  class="button primary" name="submit" value="dashboard" >Go to your Dashboard</button>
+        <button type="submit" class="button primary" name="submit" value="advice">Ask for advice</button>
+        <button type="submit" class="button primary" name="submit" value="dashboard" >Go to your Dashboard</button>
       <% end %>
     </form>
   </div>

--- a/lib/advisor/web/templates/landing_page/index.html.eex
+++ b/lib/advisor/web/templates/landing_page/index.html.eex
@@ -7,12 +7,14 @@
   <div class="login-form">
     <form action="/begin" method="post">
       <input type="email" name="email" placeholder="Put your email here" />
-      <button type="submit"  class="button primary" name="request"><%= @button %></button>
-      <input type="hidden" name="_csrf_token" value="<%= csrf_token() %>">
+      <input type="hidden" name="_csrf_token" value="<%= get_csrf_token() %>">
       <%= if @target do %>
         <input type="hidden" name="target" value="<%= @target %>">
+        <button type="submit"  class="button primary" name="submit" value="redirect">Login</button>
+      <% else %>
+        <button type="submit"  class="button primary" name="submit" value="advice">Ask for advice</button>
+        <button type="submit"  class="button primary" name="submit" value="dashboard" >Go to your Dashboard</button>
       <% end %>
-      <button type="submit"  class="button primary" name="dashboard" >Go to your Dashboard</button>
     </form>
   </div>
 </section>

--- a/lib/advisor/web/views/landing_page_view.ex
+++ b/lib/advisor/web/views/landing_page_view.ex
@@ -2,7 +2,4 @@ defmodule Advisor.Web.LandingPageView do
   alias Phoenix.Controller
   use Advisor.Web, :view
 
-  def csrf_token() do
-    Controller.get_csrf_token()
-  end
 end

--- a/test/web/controllers/login_controller_test.exs
+++ b/test/web/controllers/login_controller_test.exs
@@ -2,21 +2,21 @@ defmodule Advisor.Web.LoginControllerTest do
   use Advisor.Web.ConnCase
 
   test "Proper login to request page", %{conn: conn} do
-    conn = post conn, "/begin", [email: "felipe@example.com", request: ""]
+    conn = post conn, "/begin", [email: "felipe@example.com", submit: "advice"]
 
     assert redirected_to(conn) =~ "/request"
     assert conn.cookies["user"] == "11"
   end
 
   test "Login to the dashboard", %{conn: conn} do
-    conn = post conn, "/begin", [email: "felipe@example.com", dashboard: ""]
+    conn = post conn, "/begin", [email: "felipe@example.com", submit: "dashboard"]
 
     assert redirected_to(conn) =~ "/dashboard"
     assert conn.cookies["user"] == "11"
   end
 
   test "Fails to login with unkown email", %{conn: conn} do
-    conn = post conn, "/begin", [email: "bob@example.com", request: ""]
+    conn = post conn, "/begin", [email: "bob@example.com", submit: "advice"]
 
     assert redirected_to(conn) == "/"
     refute conn.cookies["user"]
@@ -25,7 +25,7 @@ defmodule Advisor.Web.LoginControllerTest do
   test "Redirect to original path if this was a bounced login", %{conn: conn} do
     conn = conn
            |> put_req_cookie("target", "/foo/bar")
-           |> post("/begin", [email: "felipe@example.com", request: ""])
+           |> post("/begin", [email: "felipe@example.com", submit: "redirect"])
 
     assert redirected_to(conn) == "/foo/bar"
   end


### PR DESCRIPTION
The landing page is now displayed in two varietes:
 - when just going to "/", you'll see "Ask for advice" and "Dashboard" buttons
 - when you follow a link and you are not authenticated, you'll see the landing page with only "login"