### PR TITLE
Remove the connected user from the list of people

### DIFF
--- a/lib/advisor/core/people/people.ex
+++ b/lib/advisor/core/people/people.ex
@@ -3,7 +3,11 @@ defmodule Advisor.Core.People do
   alias Advisor.Core.Person
   import Ecto.Query
 
-  def everybody(), do: Repo.all(Person)
+  def everybody_but(user) do
+    Enum.filter(everybody(), fn(person) -> person.email !=  user.email end)
+  end
+
+  defp everybody(), do: Repo.all(Person)
 
   def find_by_id(id), do: find_by([id: id])
 

--- a/lib/advisor/core/questionnaire/form.ex
+++ b/lib/advisor/core/questionnaire/form.ex
@@ -1,7 +1,7 @@
 defmodule Advisor.Core.Questionnaire.Form do
   alias Advisor.Core.{People, Questions}
 
-  def data_of(person) do
+  def data_for(person) do
     everybody = People.everybody_but(person)
     group_leads = Enum.filter(everybody, &who_is_a_group_lead/1)
     questions = Questions.all()

--- a/lib/advisor/core/questionnaire/form.ex
+++ b/lib/advisor/core/questionnaire/form.ex
@@ -1,8 +1,8 @@
 defmodule Advisor.Core.Questionnaire.Form do
   alias Advisor.Core.{People, Questions}
 
-  def data() do
-    everybody = People.everybody()
+  def data_of(connected_user) do
+    everybody = People.everybody_but(connected_user)
     group_leads = Enum.filter(everybody, &who_is_a_group_lead/1)
     questions = Questions.all()
 

--- a/lib/advisor/core/questionnaire/form.ex
+++ b/lib/advisor/core/questionnaire/form.ex
@@ -1,8 +1,8 @@
 defmodule Advisor.Core.Questionnaire.Form do
   alias Advisor.Core.{People, Questions}
 
-  def data_of(connected_user) do
-    everybody = People.everybody_but(connected_user)
+  def data_of(person) do
+    everybody = People.everybody_but(person)
     group_leads = Enum.filter(everybody, &who_is_a_group_lead/1)
     questions = Questions.all()
 

--- a/lib/advisor/web/controllers/questionnaire_page.ex
+++ b/lib/advisor/web/controllers/questionnaire_page.ex
@@ -6,7 +6,7 @@ defmodule Advisor.Web.QuestionnairePage do
   plug  Advisor.Web.Authentication.Gatekeeper
 
   def index(conn, _params) do
-    {everybody, group_leads, questions} = QuestionnaireForm.data_of(User.of(conn))
+    {everybody, group_leads, questions} = QuestionnaireForm.data_for(User.of(conn))
 
     render conn, "request.html", requester: User.of(conn),
       group_leads: group_leads,

--- a/lib/advisor/web/controllers/questionnaire_page.ex
+++ b/lib/advisor/web/controllers/questionnaire_page.ex
@@ -6,7 +6,7 @@ defmodule Advisor.Web.QuestionnairePage do
   plug  Advisor.Web.Authentication.Gatekeeper
 
   def index(conn, _params) do
-    {everybody, group_leads, questions} = QuestionnaireForm.data()
+    {everybody, group_leads, questions} = QuestionnaireForm.data_of(User.of(conn))
 
     render conn, "request.html", requester: User.of(conn),
       group_leads: group_leads,

--- a/lib/advisor/web/templates/questionnaire_page/_advisors.html.eex
+++ b/lib/advisor/web/templates/questionnaire_page/_advisors.html.eex
@@ -1,7 +1,7 @@
-<ul class="people-picker">
+<ul class="people-picker collection-wrapper">
   <%= inputs_for @form, :advisors, fn advisors_form -> %>
     <%= for person <- @everybody do %>
-      <li>
+      <li class="advisor">
         <%= checkbox(advisors_form, String.to_atom("#{person.id}")) %>
         <%= label(advisors_form, :advisor, "", for: "proposal_advisors_#{person.id}", class: "people-picker", style: "background: url(#{person.profile_image}); background-size: cover;") %>
         <span class="name"><%= person.name %></span>

--- a/lib/advisor/web/templates/questionnaire_page/_group_leads.html.eex
+++ b/lib/advisor/web/templates/questionnaire_page/_group_leads.html.eex
@@ -1,6 +1,6 @@
-<ul class="people-picker">
+<ul class="people-picker collection-wrapper">
   <%= for person <- @leads do %>
-    <li>
+    <li class="group-lead">
       <%= radio_button(@form ,:group_lead, person.id) %>
       <%= label(@form, :group_lead, "", for: "proposal_group_lead_#{person.id}", class: "people-picker", style: "background: url(#{person.profile_image}); background-size: cover;", ) %>
       <span class="name"><%= person.name %></span>

--- a/test/web/controllers/questionnaire_page_test.exs
+++ b/test/web/controllers/questionnaire_page_test.exs
@@ -19,10 +19,15 @@ defmodule Advisor.Web.RequestPageTest do
              |> Enum.at(0)
              |> Floki.text == "Hello Felipe Sere!"
 
-    # maybe split this later into group_lead and advisor
+    number_of_group_lead = 4
     assert response
-             |> Floki.find(".people-picker li")
-             |> length == 27
+             |> Floki.find(".group-lead")
+             |> length == number_of_group_lead
+
+    number_of_advisors = 23
+    assert response
+             |> Floki.find(".advisor")
+             |> length == number_of_advisors
 
     assert response
              |> Floki.find(".question-picker li")

--- a/test/web/controllers/questionnaire_page_test.exs
+++ b/test/web/controllers/questionnaire_page_test.exs
@@ -22,7 +22,7 @@ defmodule Advisor.Web.RequestPageTest do
     # maybe split this later into group_lead and advisor
     assert response
              |> Floki.find(".people-picker li")
-             |> length == 29
+             |> length == 27
 
     assert response
              |> Floki.find(".question-picker li")


### PR DESCRIPTION
You can test this through the page `/request`. 
Everyone will be displayed except the connected user in the list of _group lead_ and _people_