### PR TITLE
Make the Questions module independent of Questionnaire

### DIFF
--- a/lib/advisor/core/questionnaire/questionnaire.ex
+++ b/lib/advisor/core/questionnaire/questionnaire.ex
@@ -26,6 +26,10 @@ defmodule Advisor.Core.Questionnaire do
     Repo.all(from q in Questionnaire, where: q.id in ^ids)
   end
 
+  def questions(id) do
+    Repo.one(from q in Questionnaire, where: q.id == ^id, select: q.question_ids)
+  end
+
   def with_requester(person) do
     Repo.one(from q in Questionnaire, where: q.requester_id == ^person)
   end

--- a/lib/advisor/core/questions/questions.ex
+++ b/lib/advisor/core/questions/questions.ex
@@ -1,6 +1,6 @@
 defmodule Advisor.Core.Questions do
   alias Advisor.Repo
-  alias Advisor.Core.{Question, Questionnaire}
+  alias Advisor.Core.Question
   import Ecto.Query
 
   def all() do
@@ -12,14 +12,6 @@ defmodule Advisor.Core.Questions do
 
   def find(ids) do
     Repo.all(from q in Question, where: q.id in ^ids)
-  end
-
-  def of_questionnaire(id) do
-    questions = from q in Question,
-      join: qs in Questionnaire, on: q.id in qs.question_ids,
-      where: qs.id == ^id
-
-    Repo.all(questions)
   end
 
   def phrases(questions) do

--- a/lib/advisor/core/summary/summary.ex
+++ b/lib/advisor/core/summary/summary.ex
@@ -1,6 +1,6 @@
 defmodule Advisor.Core.Summary do
   alias Advisor.Core.{Person, Answer, Advice}
-  alias Advisor.Core.Questions
+  alias Advisor.Core.{Questions, Questionnaire}
   alias Advisor.Repo
   import Ecto.Query
 
@@ -17,7 +17,10 @@ defmodule Advisor.Core.Summary do
               |> Repo.all()
               |> Enum.map(fn({ts, adv, req, answers}) -> [ts, adv, req] ++ answers end)
 
-    questions = id |> Questions.of_questionnaire() |> Questions.phrases()
+    questions = id
+                |> Questionnaire.questions()
+                |> Questions.find()
+                |> Questions.phrases()
     header = ["timestamp", "advisor", "requester"] ++ questions
 
     [header | content]

--- a/lib/advisor/web/controllers/provide_advice_controller.ex
+++ b/lib/advisor/web/controllers/provide_advice_controller.ex
@@ -1,6 +1,6 @@
 defmodule Advisor.Web.ProvideAdviceController do
   use Advisor.Web, :controller
-  alias Advisor.Core.{People, Questions, Answers, Advice}
+  alias Advisor.Core.{People, Questions, Questionnaire, Answers, Advice}
 
   import Advisor.Web.Authentication.User, only: [found_in: 1]
 
@@ -10,7 +10,9 @@ defmodule Advisor.Web.ProvideAdviceController do
     advice = Advice.find(id, from_advisor: found_in(conn))
 
     if advice do
-      questions = Questions.of_questionnaire(advice.questionnaire_id)
+      questions = advice.questionnaire_id
+                  |> Questionnaire.questions()
+                  |> Questions.find()
       requester = People.find_by(id: advice.requester_id)
       render(conn, "advice-form.html", requester: requester,
                                        questions: questions,


### PR DESCRIPTION
To be able to use questions from a YAML file or similar, it is necessary
to reduce any dependencies between the two modules to pure ids or data
structures.

