### PR TITLE
Refactor dashboard tests

### DIFF
--- a/lib/advisor/web/templates/dashboard_page/dashboard_requester.html.eex
+++ b/lib/advisor/web/templates/dashboard_page/dashboard_requester.html.eex
@@ -1,4 +1,4 @@
-<li class="open-advice-requets">
+<li class="open-advice-requests">
   <img class="profile-image"  src="<%= @advice.requester.profile_image %>">
   <p><%= @advice.requester.name %></p>
   <a href="<%= provide_advice_path(Advisor.Web.Endpoint, :index, @advice.advice.id) %>" target="_blank" class="button primary profile-size">Give advice now</a>


### PR DESCRIPTION
### Removed usage of Floki
**Why:** Tying to HTML/CSS elements leads to fragile tests for no real benefit. There was also a typo in the css class which meant a change in both the html page and the tests even though no business behaviour changed. What you want to be testing is that the right data appear on the page; the business logic is executed.  

### Used build_conn() instead of passing the map
**Why:** The map makes sense if you're passing other things with it as well that are created on pre-test setup block. For a normal conn, `build_conn()` reads better. Note: `conn()` will be deprecated hence the usage of `build_conn()`

### Removed extra `200` assertions
**Why:** All the tests exercise the same page so you only need 1 check for the status which happens on the first test anw.

Let me know your thoughts 🙂